### PR TITLE
fix: outside click close mobile menu dropdown

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,37 +1,56 @@
-import React, { useState } from "react";
-import { RiCloseLine } from "react-icons/ri";
-import { FaLaptopCode } from "react-icons/fa";
-import { NavLink, Link, useNavigate } from "react-router-dom";
+import React, { useRef, useState } from "react"
+import { RiCloseLine } from "react-icons/ri"
+import { FaLaptopCode } from "react-icons/fa"
+import { NavLink, Link, useNavigate } from "react-router-dom"
 
-import { GoThreeBars } from "react-icons/go";
+import { GoThreeBars } from "react-icons/go"
+import { useEffect } from "react"
 
 const Navbar = () => {
-  const navigate = useNavigate();
-  const [menu, setMenu] = useState(false);
+  const navigate = useNavigate()
+  const [menu, setMenu] = useState(false)
+  const menuDropdownRef = useRef(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (
+        menuDropdownRef.current &&
+        !menuDropdownRef.current.contains(e.target)
+      ) {
+        setMenu(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [])
 
   function onClose() {
-    setMenu(false);
+    setMenu(false)
   }
   function onOpen() {
-    setMenu(true);
+    setMenu(true)
   }
   function closeMenu() {
-    setMenu(false);
+    setMenu(false)
   }
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
       behavior: "smooth",
-    });
-  };
+    })
+  }
   const handleRouteAndSectionChange = (route, section) => {
-    navigate(route);
+    navigate(route)
 
-    const sectionElement = document.querySelector(section);
+    const sectionElement = document.querySelector(section)
     if (sectionElement) {
-      sectionElement.scrollIntoView({ behavior: "smooth" });
+      sectionElement.scrollIntoView({ behavior: "smooth" })
     }
-  };
+  }
   return (
     <div className="flex flex-row px-5 md:px-10 py-4  items-center justify-between  z-[300] w-full fixed top-0 bg-[#161616] opacity-80 ">
       <div className="flex flex-row items-center justify-center space-x-2 cursor-pointer">
@@ -87,7 +106,7 @@ const Navbar = () => {
           </a>
         </p>
       </div>
-      <div className="md:hidden">
+      <div ref={menuDropdownRef} className="md:hidden">
         {menu ? (
           <RiCloseLine
             color="#687eff"
@@ -148,7 +167,7 @@ const Navbar = () => {
         )}
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default Navbar;
+export default Navbar


### PR DESCRIPTION
Fixes the mobile menu dropdown behavior.
When clicking on the mobile menu dropdown menu, the menu opens as expected.
However, a bug was causing the menu to remain open even when clicking outside of it.
This fix addresses the issue by adding a click event listener to the document.
When a click occurs outside of the menu dropdown element, the menu is now correctly closed.
This enhancement improves the user experience on mobile devices, ensuring that the menu behaves.